### PR TITLE
Update (2023.07.03)

### DIFF
--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2017, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2277,7 +2277,7 @@ void MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register resR
       move(AT, R0);
       bnez(scrReg, DONE_SET);
 
-      membar(Assembler::Membar_mask_bits(LoadLoad|LoadStore));
+      membar(Assembler::Membar_mask_bits(LoadStore|StoreStore));
       st_d(R0, Address(tmpReg, ObjectMonitor::owner_offset_in_bytes() - 2));
       li(resReg, 1);
       b(DONE);

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -1826,7 +1826,7 @@ void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
 
   bind(fail);
   if (barrier)
-    membar(LoadLoad);
+    dbar(0x700);
   if (retold && oldval != R0)
     move(oldval, resflag);
   move(resflag, R0);
@@ -1849,7 +1849,7 @@ void MacroAssembler::cmpxchg(Address addr, Register oldval, Register newval,
 
   bind(neq);
   if (barrier)
-    membar(LoadLoad);
+    dbar(0x700);
   if (retold && oldval != R0)
     move(oldval, tmp);
   if (fail)
@@ -1874,7 +1874,7 @@ void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval,
 
   bind(fail);
   if (barrier)
-    membar(LoadLoad);
+    dbar(0x700);
   if (retold && oldval != R0)
     move(oldval, resflag);
   move(resflag, R0);
@@ -1899,7 +1899,7 @@ void MacroAssembler::cmpxchg32(Address addr, Register oldval, Register newval, R
 
   bind(neq);
   if (barrier)
-    membar(LoadLoad);
+    dbar(0x700);
   if (retold && oldval != R0)
     move(oldval, tmp);
   if (fail)
@@ -4482,10 +4482,14 @@ void MacroAssembler::membar(Membar_mask_bits hint){
   address last = code()->last_insn();
   if (last != NULL && ((NativeInstruction*)last)->is_sync() && prev == last) {
     code()->set_last_insn(NULL);
+    NativeMembar *membar = (NativeMembar*)prev;
+    // merged membar
+    // e.g. LoadLoad and LoadLoad|LoadStore to LoadLoad|LoadStore
+    membar->set_hint(membar->get_hint() & (~hint & 0xF));
     block_comment("merged membar");
   } else {
     code()->set_last_insn(pc());
-    dbar(hint);
+    Assembler::membar(hint);
   }
 }
 

--- a/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/nativeInst_loongarch.hpp
@@ -518,4 +518,11 @@ inline NativeCallTrampolineStub* nativeCallTrampolineStub_at(address addr) {
   assert(ni->is_NativeCallTrampolineStub_at(), "no call trampoline found");
   return (NativeCallTrampolineStub*)addr;
 }
+
+class NativeMembar : public NativeInstruction {
+public:
+  unsigned int get_hint() { return Assembler::low(insn_word(), 4); }
+  void set_hint(int hint) { Assembler::patch(addr_at(0), 4, hint); }
+};
+
 #endif // CPU_LOONGARCH_NATIVEINST_LOONGARCH_HPP

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -2242,38 +2242,6 @@ void TemplateTable::_return(TosState state) {
   __ jr(T4);
 }
 
-// ----------------------------------------------------------------------------
-// Volatile variables demand their effects be made known to all CPU's
-// in order.  Store buffers on most chips allow reads & writes to
-// reorder; the JMM's ReadAfterWrite.java test fails in -Xint mode
-// without some kind of memory barrier (i.e., it's not sufficient that
-// the interpreter does not reorder volatile references, the hardware
-// also must not reorder them).
-//
-// According to the new Java Memory Model (JMM):
-// (1) All volatiles are serialized wrt to each other.  ALSO reads &
-//     writes act as aquire & release, so:
-// (2) A read cannot let unrelated NON-volatile memory refs that
-//     happen after the read float up to before the read.  It's OK for
-//     non-volatile memory refs that happen before the volatile read to
-//     float down below it.
-// (3) Similar a volatile write cannot let unrelated NON-volatile
-//     memory refs that happen BEFORE the write float down to after the
-//     write.  It's OK for non-volatile memory refs that happen after the
-//     volatile write to float up before it.
-//
-// We only put in barriers around volatile refs (they are expensive),
-// not _between_ memory refs (that would require us to track the
-// flavor of the previous memory refs).  Requirements (2) and (3)
-// require some barriers before volatile stores and after volatile
-// loads.  These nearly cover requirement (1) but miss the
-// volatile-store-volatile-load case.  This final case is placed after
-// volatile-stores although it could just as well go before
-// volatile-loads.
-void TemplateTable::volatile_barrier() {
-  if(os::is_MP()) __ membar(__ StoreLoad);
-}
-
 // we dont shift left 2 bits in get_cache_and_index_at_bcp
 // for we always need shift the index we use it. the ConstantPoolCacheEntry
 // is 16-byte long, index is the index in
@@ -2469,7 +2437,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(MacroAssembler::AnyAny);
     __ bind(notVolatile);
   }
 
@@ -2615,7 +2583,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
     __ bind(notVolatile);
   }
 }
@@ -2731,7 +2699,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ StoreStore | __ LoadStore));
     __ bind(notVolatile);
   }
 
@@ -2903,7 +2871,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ StoreLoad | __ StoreStore));
     __ bind(notVolatile);
   }
 }
@@ -3012,7 +2980,7 @@ void TemplateTable::fast_storefield(TosState state) {
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ StoreStore | __ LoadStore));
     __ bind(notVolatile);
   }
 
@@ -3061,7 +3029,7 @@ void TemplateTable::fast_storefield(TosState state) {
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ StoreLoad | __ StoreStore));
     __ bind(notVolatile);
   }
 }
@@ -3112,7 +3080,7 @@ void TemplateTable::fast_accessfield(TosState state) {
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(MacroAssembler::AnyAny);
     __ bind(notVolatile);
   }
 
@@ -3156,7 +3124,7 @@ void TemplateTable::fast_accessfield(TosState state) {
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
     __ bind(notVolatile);
   }
 }
@@ -3186,7 +3154,7 @@ void TemplateTable::fast_xaccess(TosState state) {
 
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(MacroAssembler::AnyAny);
     __ bind(notVolatile);
   }
 
@@ -3211,7 +3179,7 @@ void TemplateTable::fast_xaccess(TosState state) {
   {
     Label notVolatile;
     __ beq(scratch, R0, notVolatile);
-    volatile_barrier();
+    __ membar(Assembler::Membar_mask_bits(__ LoadLoad | __ LoadStore));
     __ bind(notVolatile);
   }
 }

--- a/src/hotspot/os_cpu/linux_loongarch/atomic_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/atomic_linux_loongarch.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2021, Loongson Technology. All rights reserved.
+ * Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,7 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T exchange_value,
       "   sc.w  %[__cmp],  %[__dest]  \n\t"
       "   beqz  %[__cmp],  1b    \n\t"
       "2:        \n\t"
-      "  dbar 0        \n\t"
+      "  dbar 0x700        \n\t"
 
       : [__prev] "=&r" (__prev), [__cmp] "=&r" (__cmp)
       : [__dest] "ZC" (*(volatile jint*)dest), [__old] "r" (compare_value),  [__new] "r" (exchange_value)
@@ -147,7 +147,7 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T exchange_value,
       "   sc.d  %[__cmp],  %[__dest]  \n\t"
       "   beqz  %[__cmp],  1b    \n\t"
       "2:        \n\t"
-      "   dbar 0 \n\t"
+      "   dbar 0x700 \n\t"
 
       : [__prev] "=&r" (__prev), [__cmp] "=&r" (__cmp)
       : [__dest] "ZC" (*(volatile jlong*)dest), [__old] "r" (compare_value),  [__new] "r" (exchange_value)

--- a/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
+++ b/src/hotspot/os_cpu/linux_loongarch/orderAccess_linux_loongarch.hpp
@@ -31,19 +31,19 @@
 // Included in orderAccess.hpp header file.
 
 // Implementation of class OrderAccess.
-#define inlasm_sync() if (os::is_ActiveCoresMP()) \
+#define inlasm_sync(v) if (os::is_ActiveCoresMP()) \
                         __asm__ __volatile__ ("nop"   : : : "memory"); \
                       else \
-                        __asm__ __volatile__ ("dbar 0"   : : : "memory");
+                        __asm__ __volatile__ ("dbar %0"   : :"K"(v) : "memory");
 
-inline void OrderAccess::loadload()   { inlasm_sync(); }
-inline void OrderAccess::storestore() { inlasm_sync(); }
-inline void OrderAccess::loadstore()  { inlasm_sync(); }
-inline void OrderAccess::storeload()  { inlasm_sync(); }
+inline void OrderAccess::loadload()   { inlasm_sync(0x15); }
+inline void OrderAccess::storestore() { inlasm_sync(0x1a); }
+inline void OrderAccess::loadstore()  { inlasm_sync(0x16); }
+inline void OrderAccess::storeload()  { inlasm_sync(0x19); }
 
-inline void OrderAccess::acquire() { inlasm_sync(); }
-inline void OrderAccess::release() { inlasm_sync(); }
-inline void OrderAccess::fence()   { inlasm_sync(); }
+inline void OrderAccess::acquire() { inlasm_sync(0x14); }
+inline void OrderAccess::release() { inlasm_sync(0x12); }
+inline void OrderAccess::fence()   { inlasm_sync(0x10); }
 
 
 #undef inlasm_sync


### PR DESCRIPTION
30358: Add support for ordering memory barriers
30456: Fix a typo membar_acquire to membar_release