### PR TITLE
Update (2023.08.14)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/gc/shared/cardTableBarrierSetAssembler_loongarch.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, Loongson Technology. All rights reserved.
+ * Copyright (c) 2018, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembl
 
   __ beq(count, R0, L_done); // zero count - nothing to do
 
-  if (UseConcMarkSweepGC) __ membar(__ StoreStore);
+  if (ct->scanned_concurrently()) __ membar(__ StoreStore);
 
   __ li(tmp, disp);
 
@@ -102,8 +102,6 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
 
   jbyte dirty = CardTable::dirty_card_val();
   if (UseCondCardMark) {
-    Untested("Untested");
-    __ warn("store_check Untested");
     Label L_already_dirty;
     __ membar(__ StoreLoad);
     __ ld_b(AT, tmp, 0);
@@ -113,7 +111,7 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
     __ bind(L_already_dirty);
   } else {
     if (ct->scanned_concurrently()) {
-      __ membar(Assembler::StoreLoad);
+      __ membar(Assembler::StoreStore);
     }
     __ st_b(R0, tmp, 0);
   }

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2015, 2022, Loongson Technology. All rights reserved.
+// Copyright (c) 2015, 2023, Loongson Technology. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -10061,14 +10061,25 @@ instruct cmpFastUnlock(FlagsReg cr, mRegP object, mRegP box, mRegI tmp, mRegI sc
 %}
 
 // Store CMS card-mark Immediate 0
+instruct storeImmCM_order(memory mem, immI_0 zero) %{
+  match(Set mem (StoreCM mem zero));
+  predicate(UseConcMarkSweepGC && !UseCondCardMark);
+  ins_cost(100);
+  format %{ "StoreCM MEMBAR storestore\n\t"
+            "st_b   $mem, zero\t! card-mark imm0" %}
+  ins_encode %{
+    __ membar(__ StoreStore);
+    __ loadstore_enc(R0, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, MacroAssembler::STORE_BYTE);
+  %}
+  ins_pipe( ialu_storeI );
+%}
+
 instruct storeImmCM(memory mem, immI_0 zero) %{
   match(Set mem (StoreCM mem zero));
 
   ins_cost(150);
-  format %{ "StoreCM MEMBAR loadstore\n\t"
-            "st_b   $mem, zero\t! CMS card-mark imm0" %}
+  format %{ "st_b   $mem, zero\t! card-mark imm0" %}
   ins_encode %{
-    __ membar(__ StoreStore);
     __ loadstore_enc(R0, $mem$$base, $mem$$index, $mem$$scale, $mem$$disp, MacroAssembler::STORE_BYTE);
   %}
   ins_pipe( ialu_storeI );

--- a/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubGenerator_loongarch_64.cpp
@@ -707,8 +707,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // disjoint large copy
   void generate_disjoint_large_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label loop, le32, le16, le8, lt8;
 
@@ -788,8 +788,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // disjoint large copy lsx
   void generate_disjoint_large_copy_lsx(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label loop, le64, le32, le16, lt16;
 
@@ -870,8 +870,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // disjoint large copy lasx
   void generate_disjoint_large_copy_lasx(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label loop, le128, le64, le32, lt32;
 
@@ -952,8 +952,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // conjoint large copy
   void generate_conjoint_large_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label loop, le32, le16, le8, lt8;
 
@@ -1030,8 +1030,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // conjoint large copy lsx
   void generate_conjoint_large_copy_lsx(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label loop, le64, le32, le16, lt16;
 
@@ -1109,8 +1109,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // conjoint large copy lasx
   void generate_conjoint_large_copy_lasx(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label loop, le128, le64, le32, lt32;
 
@@ -1188,8 +1188,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // Byte small copy: less than { int:9, lsx:17, lasx:33 } elements.
   void generate_byte_small_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label L;
     __ bind(entry);
@@ -1554,8 +1554,8 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_disjoint_byte_copy(bool aligned, Label &small, Label &large,
                                       Label &large_aligned, const char * name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     if (UseLASX)
@@ -1594,8 +1594,8 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_conjoint_byte_copy(bool aligned, Label &small, Label &large,
                                       Label &large_aligned, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     array_overlap_test(StubRoutines::jbyte_disjoint_arraycopy(), 0);
@@ -1621,8 +1621,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // Short small copy: less than { int:9, lsx:9, lasx:17 } elements.
   void generate_short_small_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label L;
     __ bind(entry);
@@ -1833,8 +1833,8 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_disjoint_short_copy(bool aligned, Label &small, Label &large,
                                        Label &large_aligned, const char * name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     if (UseLASX)
@@ -1873,8 +1873,8 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_conjoint_short_copy(bool aligned, Label &small, Label &large,
                                        Label &large_aligned, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     array_overlap_test(StubRoutines::jshort_disjoint_arraycopy(), 1);
@@ -1900,8 +1900,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // Int small copy: less than { int:7, lsx:7, lasx:9 } elements.
   void generate_int_small_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label L;
     __ bind(entry);
@@ -2137,8 +2137,8 @@ class StubGenerator: public StubCodeGenerator {
   address generate_disjoint_int_oop_copy(bool aligned, bool is_oop, Label &small,
                                          Label &large, Label &large_aligned, const char *name,
                                          int small_limit, bool dest_uninitialized = false) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     gen_maybe_oop_copy(is_oop, true, aligned, small, large, large_aligned,
@@ -2165,8 +2165,8 @@ class StubGenerator: public StubCodeGenerator {
   address generate_conjoint_int_oop_copy(bool aligned, bool is_oop, Label &small,
                                          Label &large, Label &large_aligned, const char *name,
                                          int small_limit, bool dest_uninitialized = false) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     if (is_oop) {
@@ -2183,8 +2183,8 @@ class StubGenerator: public StubCodeGenerator {
 
   // Long small copy: less than { int:4, lsx:4, lasx:5 } elements.
   void generate_long_small_copy(Label &entry, const char *name) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
 
     Label L;
     __ bind(entry);
@@ -2287,8 +2287,8 @@ class StubGenerator: public StubCodeGenerator {
   address generate_disjoint_long_oop_copy(bool aligned, bool is_oop, Label &small,
                                           Label &large, Label &large_aligned, const char *name,
                                           int small_limit, bool dest_uninitialized = false) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     gen_maybe_oop_copy(is_oop, true, aligned, small, large, large_aligned,
@@ -2315,8 +2315,8 @@ class StubGenerator: public StubCodeGenerator {
   address generate_conjoint_long_oop_copy(bool aligned, bool is_oop, Label &small,
                                           Label &large, Label &large_aligned, const char *name,
                                           int small_limit, bool dest_uninitialized = false) {
-    StubCodeMark mark(this, "StubRoutines", name);
     __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
     address start = __ pc();
 
     if (is_oop) {

--- a/src/hotspot/cpu/mips/gc/shared/cardTableBarrierSetAssembler_mips.cpp
+++ b/src/hotspot/cpu/mips/gc/shared/cardTableBarrierSetAssembler_mips.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2022, Loongson Technology. All rights reserved.
+ * Copyright (c) 2018, 2023, Loongson Technology. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembl
   __ beq(count, R0, L_done); // zero count - nothing to do
   __ delayed()->nop();
 
-  if (UseConcMarkSweepGC) __ sync();
+  if (ct->scanned_concurrently()) __ membar(Assembler::StoreStore);
 
   __ set64(tmp, disp);
 
@@ -108,8 +108,6 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
 
   jbyte dirty = CardTable::dirty_card_val();
   if (UseCondCardMark) {
-    Untested("Untested");
-    __ warn("store_check Untested");
     Label L_already_dirty;
     __ membar(Assembler::StoreLoad);
     __ lb(AT, tmp, 0);
@@ -120,7 +118,7 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
     __ bind(L_already_dirty);
   } else {
     if (ct->scanned_concurrently()) {
-      __ membar(Assembler::StoreLoad);
+      __ membar(Assembler::StoreStore);
     }
     __ sb(R0, tmp, 0);
   }


### PR DESCRIPTION
31485: Incomplete implementation of 8202082
30418: StoreStore only be used for CMS with no conditional card marking
27957: Mark stub code without alignment padding