### PR TITLE
Update (2023.12.08)

### DIFF
--- a/src/hotspot/cpu/loongarch/frame_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.cpp
@@ -543,7 +543,7 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
 
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method* m = safe_interpreter_frame_method();
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;


### PR DESCRIPTION
32079: LA port of 8313796: AsyncGetCallTrace crash on unreadable interpreter method pointer