### PR TITLE
Update (2024.01.26)

### DIFF
--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -159,7 +159,7 @@ void VM_Version::get_processor_features() {
   _supports_cx8 = true;
 
   if (UseG1GC && FLAG_IS_DEFAULT(MaxGCPauseMillis)) {
-    FLAG_SET_CMDLINE(uintx, MaxGCPauseMillis, 150);
+    FLAG_SET_DEFAULT(MaxGCPauseMillis, 150);
   }
 
   if (supports_lsx()) {

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -159,7 +159,7 @@ void VM_Version::get_processor_features() {
   _supports_cx8 = true;
 
   if (UseG1GC && FLAG_IS_DEFAULT(MaxGCPauseMillis)) {
-    FLAG_SET_CMDLINE(uintx, MaxGCPauseMillis, 650);
+    FLAG_SET_CMDLINE(uintx, MaxGCPauseMillis, 150);
   }
 
   if (supports_lsx()) {


### PR DESCRIPTION
32519: Fix for 31967 set default MaxGCPauseMillis
31967: [G1GC] Set default MaxGCPauseMillis=150ms